### PR TITLE
 Remove windows from cross platform build till able to fix syscall.SI…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: cross compile
           command: |
-            gox -os="linux darwin windows" -arch="amd64" -output="dist/gobc_{{.OS}}_{{.Arch}}"
+            gox -os="linux darwin" -arch="amd64" -output="dist/gobc_{{.OS}}_{{.Arch}}"
             cd dist/ && gzip *
 workflows:
   version: 2


### PR DESCRIPTION
…GSTP / syscall.SIGSTOP issue is resolved for go 1.12.1